### PR TITLE
[Wonseok] 프론트 실행용 도커 파일 추가

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,7 @@
+Dockerfile
+.dockerignore
+node_modules
+npm-debug.log
+README.md
+.next
+.git

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,29 @@
+###################################
+# Stage 1: 종속성 설치 및 nextjs 빌드 #
+###################################
+FROM node:22-alpine as build
+
+# nextjs를 빌드하고 실행할 위치
+WORKDIR /app
+COPY . .
+
+# 종속성 설치 및 빌드
+RUN yarn install
+RUN yarn build
+
+###################################
+# Stage 2: nextjs 실행
+###################################
+FROM node:22-alpine
+
+WORKDIR /app
+COPY --from=build /app/.next ./.next
+COPY public ./public
+COPY package.json ./
+COPY yarn.lock ./
+
+RUN yarn install --production
+
+EXPOSE 3000
+
+CMD ["yarn", "start"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,12 +17,12 @@ RUN yarn build
 FROM node:22-alpine
 
 WORKDIR /app
-COPY --from=build /app/.next ./.next
-COPY public ./public
-COPY package.json ./
-COPY yarn.lock ./
-
-RUN yarn install --production
+COPY --from=build /app/yarn.lock .
+COPY --from=build /app/package.json .
+COPY --from=build /app/next.config.mjs .
+COPY --from=build /app/public ./public
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/.next/ ./.next
 
 EXPOSE 3000
 


### PR DESCRIPTION
## 변경사항
- 배포 환경에서 Next.js를 실행하기 위한 Dockerfile을 추가했습니다.
- 도커 이미지의 용량을 줄이기 위해 2-stage로 빌드합니다.
  - 통상적으로 빌드한다면 이미지 크기는 2.3GB입니다.
  - 2-stage로 빌드할 경우 이미지 크기는 약 700MB
- 빌드에 불필요한 파일(node_modules, README) 등이 마운트되는 것을 방지하기 위해 .dockerignore 파일을 작성했습니다.

## 테스트
로컬에서 next.js의 실행을 테스트하려면 아래와 같이 도커 이미지를 빌드하고 실행해보세요.
1. frontend 폴더로 이동합니다.
2. 도커 이미지를 빌드합니다.
```docker build -t nextjs .```
3. 도커 이미지를 실행합니다.
```docker run --rm -it --name nextjs -p 3000:3000 nextjs```
4. 브라우저에 `localhost:3000`으로 접근하여 정상동작 확인

## 비고
이번 Dockerfile은 Github Action에서 실행하기 위한 파일로, 빌드 후 DockerHub에 업로드될 예정입니다.