### PR TITLE
[Wonseok] 배포용 nginx 설정 파일 및 docker-compose 정의

### DIFF
--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -1,0 +1,23 @@
+services:
+  nginx:
+    depends_on:
+      - frontend
+    image: nginx:1.25.5-alpine
+    ports:
+      - 80:80
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    container_name: nginx
+    networks:
+      - longliveprofessorkim
+
+  frontend:
+    image: cotidie/longliveprofessorkim-frontend
+    ports:
+      - 3000:3000
+    container_name: frontend
+    networks:
+      - longliveprofessorkim
+
+networks:
+  longliveprofessorkim:

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,26 @@
+http {
+
+  include mime.types;
+
+  set_real_ip_from        0.0.0.0/0;
+  real_ip_recursive       on;
+  real_ip_header          X-Forward-For;
+  limit_req_zone          $binary_remote_addr zone=mylimit:10m rate=10r/s;
+
+  upstream docker-frontend {
+    server frontend:3000;
+  }
+
+  server {
+    listen 80;
+    server_name localhost;
+    root /proxy;
+    limit_req zone=mylimit burst=70 nodelay;
+
+    location / {
+       proxy_pass http://docker-frontend;
+    }
+  }
+}
+
+events {}


### PR DESCRIPTION
## 변경사항
- Amazon EC2 등 배포환경에서 실행할 nginx 설정 파일을 정의했습니다.
  - `cloud.longliveprofessorkim.com`으로 들어오는 트래픽은 `localhost:3000`으로 전달됩니다. (프론트 배포중인 포트)
- 이때 frontend 용 도커를 함께 실행하도록 docker-compose.yaml을 작성했습니다.
  - 프론트용 도커는 'cotidie/longliveprofessorkim-frontend' Dockerhub에서 가져옵니다.
 
## 테스트
위의 두 파일을 배포 환경으로 옮기고, `docker-compose up`을 실행하면 프론트 배포가 완료됩니다.
카톡 주시면 EC2 접근용 시크릿 키(.pem) 드릴게요!

이 설정에 따라 배포된 프론트 페이지는 [http://cloud.longliveprofessorkim.com/](http://cloud.longliveprofessorkim.com/)에서 확인 가능합니다.

## 이슈
- https는 아직 지원하지 않습니다. 아마 영원히...ㅎㅎㅎ