### PR TITLE
[Wonseok] Pull Request 시 프론트 도커 자동 빌드

### DIFF
--- a/.github/workflows/deploy-frondend.yaml
+++ b/.github/workflows/deploy-frondend.yaml
@@ -20,8 +20,6 @@ jobs:
       
       - name: debug
         uses: actions/checkout@v3
-      - run: |
-          ls ${{ github.workspace }}/frontend  
 
       - name: Build and Push
         id: front-build
@@ -29,7 +27,7 @@ jobs:
         with:
           context: ${{ github.workspace }}/frontend
           push: true
-          tags: cotidie/longliveprofessorkim-backend
+          tags: cotidie/longliveprofessorkim-frontend
 
 
 

--- a/.github/workflows/deploy-frondend.yaml
+++ b/.github/workflows/deploy-frondend.yaml
@@ -1,10 +1,12 @@
 on:
-  push:
+  pull_request:
     branches:
-      - 'wonseok/deploy-frontend-workflow'
+      - main
+    types: [labeled]
   
 jobs:
   build-image:
+    if: github.event.label.name == 'frontend'
     name: Build and Push Frontend Image
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy-frondend.yaml
+++ b/.github/workflows/deploy-frondend.yaml
@@ -17,6 +17,20 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
+      
+      - name: debug
+        uses: actions/checkout@v3
+      - run: |
+          ls ${{ github.workspace }}/frontend  
+
+      - name: Build and Push
+        id: front-build
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ github.workspace }}/frontend
+          push: true
+          tags: cotidie/longliveprofessorkim-backend
+
 
 
       

--- a/.github/workflows/deploy-frondend.yaml
+++ b/.github/workflows/deploy-frondend.yaml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches:
+      - 'wonseok/deploy-frontend-workflow'
+  
+jobs:
+  build-image:
+    name: Build and Push Frontend Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+
+      

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -35,7 +35,7 @@ const Page = () => {
               ':hover': { bgcolor: 'gray' },
             }}
           >
-            빌드 테스트
+            시작하기
           </Button>
         </Link>
       </Box>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -35,7 +35,7 @@ const Page = () => {
               ':hover': { bgcolor: 'gray' },
             }}
           >
-            시작하기
+            빌드 테스트
           </Button>
         </Link>
       </Box>


### PR DESCRIPTION
## 변경사항
- Pull Request에 'frontend' 라벨을 붙일 경우 next.js(프론트) 도커를 자동 빌드하도록 구성했습니다.
  - 이미지는 `cotidie/longliveprofessorkim-frontend` Dockerhub로 Push 됩니다.
- 기존에 올려둔 Pull Request에도 'frontend' 라벨을 붙이는 순간 빌드됩니다.

## 테스트
로컬에서 테스트한다면 다음 절차를 따라주시기 바랍니다. 
1. Pull Request에 `frontend` 태그를 붙이고 Workflow가 성공하길 기다립니다.
2. 로컬에서 프론트 도커 이미지를 삭제합니다.
`docker image rm cotidie/longliveprofessorkim-frontend`
3. 프론트 이미지를 새로 받습니다.
`docker pull cotidie/longliveprofessorkim-frontend`
4. 프론트 도커를 실행하고 변경사항을 체크합니다.
`docker run --rm -it --name frontend -p 3000:3000 cotidie/longliveprofessorkim-frontend`

## 비고
이제 AWS EC2에 프론트 도커를 재시작하도록 따로 트리거할 차례입니다.